### PR TITLE
Simplify Luaunpack and fix bugs

### DIFF
--- a/luaunpack.c
+++ b/luaunpack.c
@@ -18,6 +18,9 @@ int lunpack_newpacket(lua_State *L, void *data, lua_Integer length) {
 static packet_t *verify_mem_access(lua_State *L, lua_Integer *offset, lua_Integer *size) {
 	packet_t *packet = lua_touserdata(L, 1);
 
+	if (packet == NULL)
+		return NULL;
+
 	*offset = lua_tointeger(L, 2);
 	*size = lua_tointeger(L, 3);
 	if(packet->offset + *offset + *size > packet->length)

--- a/luaunpack.c
+++ b/luaunpack.c
@@ -8,7 +8,6 @@ int lunpack_newpacket(lua_State *L, void *data, lua_Integer length) {
 	if (packet == NULL)
 		return -ENOMEM;
 
-	packet->offset = 0;
 	packet->length = length;
 	packet->data = data;
 
@@ -23,7 +22,7 @@ static packet_t *verify_mem_access(lua_State *L, lua_Integer *offset, lua_Intege
 
 	*offset = lua_tointeger(L, 2);
 	*size = lua_tointeger(L, 3);
-	if(packet->offset + *offset + *size > packet->length)
+	if(*offset + *size > packet->length)
 		return NULL;
 
 	return packet;

--- a/luaunpack.c
+++ b/luaunpack.c
@@ -6,7 +6,7 @@ int lunpack_newpacket(lua_State *L, void *data, lua_Integer length) {
 	packet_t *packet = lua_newuserdata(L, sizeof(packet_t));
 
 	if (packet == NULL)
-		return luaL_error(L, "not enough memory");
+		return -ENOMEM;
 
 	packet->offset = 0;
 	packet->length = length;
@@ -34,13 +34,13 @@ static int unpackint(lua_State *L) {
 
 	packet = verify_mem_access(L, &offset, &size);
 	if (packet == NULL)
-		return luaL_error(L, "trying to access out of bounds memory");
+		return 0;
 
 	ptr = packet->data + offset;
 	switch (size) {
 		case 1: lua_pushinteger(L, ptr[0]);        break;
 		case 2: lua_pushinteger(L, (ptr[0] << 8) | ptr[1]); break;
-		default: luaL_error(L, "invalid size");
+		default: return 0;
 	}
 
 	return 1;
@@ -53,7 +53,7 @@ static int unpackstring(lua_State *L) {
 
 	packet = verify_mem_access(L, &offset, &size);
 	if (packet == NULL)
-		return luaL_error(L, "trying to access out of bounds memory");
+		return 0;
 
 	lua_pushlstring(L, packet->data + offset, size);
 

--- a/luaunpack.c
+++ b/luaunpack.c
@@ -2,7 +2,7 @@
 #include <lauxlib.h>
 #include <luaunpack.h>
 
-int lunpack_newpacket(lua_State *L, void *data, int length) {
+int lunpack_newpacket(lua_State *L, void *data, lua_Integer length) {
 	packet_t *packet = lua_newuserdata(L, sizeof(packet_t));
 
 	if (packet == NULL)
@@ -15,7 +15,7 @@ int lunpack_newpacket(lua_State *L, void *data, int length) {
 	return 0;
 }
 
-static packet_t *verify_mem_access(lua_State *L, unsigned int *offset, unsigned int *size) {
+static packet_t *verify_mem_access(lua_State *L, lua_Integer *offset, lua_Integer *size) {
 	packet_t *packet = lua_touserdata(L, 1);
 
 	*offset = lua_tointeger(L, 2);
@@ -27,8 +27,8 @@ static packet_t *verify_mem_access(lua_State *L, unsigned int *offset, unsigned 
 }
 
 static int unpackint(lua_State *L) {
-	unsigned int offset;
-	unsigned int size;
+	lua_Integer offset;
+	lua_Integer size;
 	packet_t *packet;
 	unsigned char *ptr;
 
@@ -48,8 +48,8 @@ static int unpackint(lua_State *L) {
 
 static int unpackstring(lua_State *L) {
 	packet_t *packet;
-	unsigned int offset;
-	unsigned int size;
+	lua_Integer offset;
+	lua_Integer size;
 
 	packet = verify_mem_access(L, &offset, &size);
 	if (packet == NULL)

--- a/luaunpack.h
+++ b/luaunpack.h
@@ -1,7 +1,6 @@
 #include <lua.h>
 
 typedef struct {
-	lua_Integer offset;
 	lua_Integer length;
 	void *data;
 } packet_t;

--- a/luaunpack.h
+++ b/luaunpack.h
@@ -1,8 +1,10 @@
+#include <lua.h>
+
 typedef struct {
-	size_t offset;
-	size_t length;
+	lua_Integer offset;
+	lua_Integer length;
 	void *data;
 } packet_t;
 
 extern int luaopen_unpack(lua_State *L);
-extern int lunpack_newpacket(lua_State *L, void *packet, int length);
+extern int lunpack_newpacket(lua_State *L, void *packet, lua_Integer length);


### PR DESCRIPTION
Bugs fixed: 
- Panic in `unpackint` and `unpackstring` when the userdata isn't in the correct stack index

Corrections: 
- Use lua_Integer when dealing with integers coming from Lua
- Don't raise error in Lua when a user tries to access out of bounds memory, just return 0
- Remove unnecessary offset field from Luaunpack's userdata

Closes #2 
Closes #3 
Closes #4 
Closes #5 